### PR TITLE
Use zero-padded hours in 12-hour mode

### DIFF
--- a/res/raw/watchface.xml
+++ b/res/raw/watchface.xml
@@ -873,7 +873,7 @@
 					<Font family="inter_medium" size="90" weight="NORMAL" slant="NORMAL" color="#ffffffff">
 						<Template>
 							%s
-							<Parameter expression="[IS_24_HOUR_MODE]? [HOUR_0_23_Z]: [HOUR_1_12]" />
+							<Parameter expression="[IS_24_HOUR_MODE]? [HOUR_0_23_Z]: [HOUR_1_12_Z]" />
 						</Template>
 					</Font>
 				</Text>


### PR DESCRIPTION
This change uses the zero-padded 12-hour source
  (`[HOUR_1_12_Z]`) for devices in 12-hour mode.

  Currently, single-digit hours are displayed without a
  leading zero in 12-hour mode, for example `6:05`, while 24-
  hour mode already uses a fixed two-digit hour format like
  `06:05`. Using the padded value makes the digital time
  display visually consistent across both time modes.

  This improves the user experience by keeping the hour and
  minute alignment stable throughout the day, especially when
  moving between single-digit and double-digit hours. It also
  gives the watch face a more balanced digital-clock
  appearance without changing 24-hour mode behavior.

  If the unpadded 12-hour display is intentional or preferred
  for this watch face, feel free to close this PR.